### PR TITLE
thrift: create git submodule for upstream thrift

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".upstream"]
+	path = .upstream
+	url = https://github.com/cfriedt/thrift.git

--- a/lib/thrift/CMakeLists.txt
+++ b/lib/thrift/CMakeLists.txt
@@ -10,6 +10,7 @@ target_compile_definitions(app PUBLIC _GLIBCXX_HAS_GTHREADS=1)
 
 zephyr_library()
 zephyr_include_directories(include)
+zephyr_include_directories(${ZEPHYR_CURRENT_MODULE_DIR}/.upstream/lib/cpp/src)
 
 zephyr_library_sources(
   src/thrift/server/TFDServer.cpp


### PR DESCRIPTION
Add a git submoudle to point to upstream thrift at
https://github.com/cfriedt/thrift.git

We will be making project-specific changes in the `zephyr` branch
of that project.

The checkout corresponds with `v0.16.0`, initially.

Placed in `.upstream` for lack of a better place.

IIRC, `west` is now configured to also clone submodules by default
so the README likely does not need to be updated.

Fixes #2