### PR TITLE
lib: thrift: CMakeLists.txt: link upstream thrift sources

### DIFF
--- a/lib/thrift/CMakeLists.txt
+++ b/lib/thrift/CMakeLists.txt
@@ -3,6 +3,8 @@
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
+set(THRIFT_UPSTREAM "${ZEPHYR_CURRENT_MODULE_DIR}/.upstream")
+
 include(${ZEPHYR_CURRENT_MODULE_DIR}/cmake/thrift.cmake)
 
 # needed in order to expose some C++ class definitions in Newlib
@@ -10,8 +12,18 @@ target_compile_definitions(app PUBLIC _GLIBCXX_HAS_GTHREADS=1)
 
 zephyr_library()
 zephyr_include_directories(include)
-zephyr_include_directories(${ZEPHYR_CURRENT_MODULE_DIR}/.upstream/lib/cpp/src)
+zephyr_include_directories(${THRIFT_UPSTREAM}/lib/cpp/src)
 
 zephyr_library_sources(
   src/thrift/server/TFDServer.cpp
+  src/thrift/server/TSimpleServer.cpp
+  ${THRIFT_UPSTREAM}/lib/cpp/src/thrift/protocol/TProtocol.cpp
+  ${THRIFT_UPSTREAM}/lib/cpp/src/thrift/server/TConnectedClient.cpp
+  ${THRIFT_UPSTREAM}/lib/cpp/src/thrift/server/TServerFramework.cpp
+  ${THRIFT_UPSTREAM}/lib/cpp/src/thrift/transport/TFDTransport.cpp
+  ${THRIFT_UPSTREAM}/lib/cpp/src/thrift/transport/TTransportException.cpp
+  ${THRIFT_UPSTREAM}/lib/cpp/src/thrift/transport/TBufferTransports.cpp
+  ${THRIFT_UPSTREAM}/lib/cpp/src/thrift/TApplicationException.cpp
+  ${THRIFT_UPSTREAM}/lib/cpp/src/thrift/TOutput.cpp
+  ${THRIFT_UPSTREAM}/lib/cpp/src/thrift/TOutput.cpp
 )

--- a/lib/thrift/src/thrift/server/TSimpleServer.cpp
+++ b/lib/thrift/src/thrift/server/TSimpleServer.cpp
@@ -1,0 +1,93 @@
+#include <thrift/server/TSimpleServer.h>
+
+using namespace std;
+using namespace apache::thrift;
+
+namespace apache
+{
+    namespace thrift
+    {
+        namespace server
+        {
+
+            TSimpleServer::TSimpleServer(
+                const shared_ptr<TProcessorFactory> &processorFactory,
+                const shared_ptr<TServerTransport> &serverTransport,
+                const shared_ptr<TTransportFactory> &transportFactory,
+                const shared_ptr<TProtocolFactory> &protocolFactory)
+                : TServerFramework(processorFactory, serverTransport, transportFactory, protocolFactory)
+            {
+            }
+
+            TSimpleServer::TSimpleServer(
+                const shared_ptr<TProcessor> &processor,
+                const shared_ptr<TServerTransport> &serverTransport,
+                const shared_ptr<TTransportFactory> &transportFactory,
+                const shared_ptr<TProtocolFactory> &protocolFactory)
+                : TServerFramework(processor, serverTransport, transportFactory, protocolFactory)
+            {
+            }
+
+            TSimpleServer::TSimpleServer(
+                const shared_ptr<TProcessorFactory> &processorFactory,
+                const shared_ptr<TServerTransport> &serverTransport,
+                const shared_ptr<TTransportFactory> &inputTransportFactory,
+                const shared_ptr<TTransportFactory> &outputTransportFactory,
+                const shared_ptr<TProtocolFactory> &inputProtocolFactory,
+                const shared_ptr<TProtocolFactory> &outputProtocolFactory)
+                : TServerFramework(processorFactory, serverTransport, inputTransportFactory, outputTransportFactory, inputProtocolFactory, outputProtocolFactory)
+            {
+            }
+
+            TSimpleServer::TSimpleServer(
+                const shared_ptr<TProcessor> &processor,
+                const shared_ptr<TServerTransport> &serverTransport,
+                const shared_ptr<TTransportFactory> &inputTransportFactory,
+                const shared_ptr<TTransportFactory> &outputTransportFactory,
+                const shared_ptr<TProtocolFactory> &inputProtocolFactory,
+                const shared_ptr<TProtocolFactory> &outputProtocolFactory)
+                : TServerFramework(processor, serverTransport, inputTransportFactory, outputTransportFactory, inputProtocolFactory, outputProtocolFactory)
+            {
+            }
+
+            TSimpleServer::~TSimpleServer()
+            {
+            }
+
+            void TSimpleServer::serve()
+            {
+            }
+
+            void TSimpleServer::stop()
+            {
+            }
+
+            int64_t TSimpleServer::getConcurrentClientLimit() const
+            {
+                return 1;
+            }
+
+            int64_t TSimpleServer::getConcurrentClientCount() const
+            {
+                return 1;
+            }
+
+            int64_t TSimpleServer::getConcurrentClientCountHWM() const
+            {
+                return 1;
+            }
+
+            void TSimpleServer::setConcurrentClientLimit(int64_t newLimit)
+            {
+            }
+
+            void TSimpleServer::onClientConnected(const shared_ptr<TConnectedClient> &pClient)
+            {
+            }
+
+            void TSimpleServer::onClientDisconnected(TConnectedClient *pClient)
+            {
+            }
+        }
+    }
+} // server


### PR DESCRIPTION
Link in sources from upstream Thrift to resolve link errors.

Also add a stubbed-out version of TSimpleServer.cpp that should allow us to externalize the thread.

Fixes #41
