### PR TITLE
cmake: thrift: remove pkgconfig executable

### DIFF
--- a/cmake/thrift.cmake
+++ b/cmake/thrift.cmake
@@ -3,7 +3,6 @@
 find_program(THRIFT_EXECUTABLE thrift)
 
 message(STATUS "Found thrift executable: ${THRIFT_EXECUTABLE}")
-message(STATUS "Found pkg-config executable: ${PKGCONFIG_EXECUTABLE}")
 
 function(thrift
     target          # CMake target (for dependencies / headers)


### PR DESCRIPTION
The pkgconfig bit was left over from earlier when the
host thrift headers were used to compile.

Fixes #52
