### PR TITLE
zephyr: remove posix prefix on standard headers

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -21,5 +21,7 @@ manifest:
       revision: master
     - name: zephyr
       remote: zephyrproject-rtos
-      revision: main
+      # Remove the need for 'posix/' prefix when including std headers
+      # https://github.com/zephyrproject-rtos/zephyr/pull/43987
+      revision: pull/43987/head
       import: true


### PR DESCRIPTION
The upstream PR is zephyrproject-rtos/zephyr#43987

Basing off of that so that we can roll-back the many changes like the one below in `.upstream` thrift.

```
 #ifdef CONFIG_SOC_POSIX
 #include <unistd.h>
 #else
 #include <posix/unistd.h>
 #endif
```

Fixes #61