### PR TITLE
samples + tests: disable posix arch temporarily

### DIFF
--- a/samples/lib/thrift/hello_client/sample.yaml
+++ b/samples/lib/thrift/hello_client/sample.yaml
@@ -3,8 +3,8 @@ sample:
   name: hello thrift
 common:
   tags: samples thrift cpp
-common:
-  tags: thrift cpp
+  # FIXME: zephyrproject-rtos/zephyr#45100
+  arch_exclude: posix
 tests:
   thrift.hello.newlib:
     filter: TOOLCHAIN_HAS_NEWLIB == 1
@@ -12,9 +12,9 @@ tests:
     platform_exclude: qemu_x86 qemu_leon3 qemu_malta qemu_malta_be
     arch_exclude: arc xtensa
     tags: newlib
-  thrift.hello.native:
-    arch_allow: posix
-    tags: native
+#  thrift.hello.native:
+#    arch_allow: posix
+#    tags: native
   thrift.hello.arcmwdtlib:
     toolchain_allow: arcmwdt
     platform_allow: nsim_hs nsim_em

--- a/samples/lib/thrift/hello_server/sample.yaml
+++ b/samples/lib/thrift/hello_server/sample.yaml
@@ -3,8 +3,8 @@ sample:
   name: hello thrift
 common:
   tags: samples thrift cpp
-common:
-  tags: thrift cpp
+  # FIXME: zephyrproject-rtos/zephyr#45100
+  arch_exclude: posix
 tests:
   thrift.hello.newlib:
     filter: TOOLCHAIN_HAS_NEWLIB == 1
@@ -12,9 +12,9 @@ tests:
     platform_exclude: qemu_x86 qemu_leon3 qemu_malta qemu_malta_be
     arch_exclude: arc xtensa
     tags: newlib
-  thrift.hello.native:
-    arch_allow: posix
-    tags: native
+#  thrift.hello.native:
+#    arch_allow: posix
+#    tags: native
   thrift.hello.arcmwdtlib:
     toolchain_allow: arcmwdt
     platform_allow: nsim_hs nsim_em

--- a/tests/lib/thrift/hello/testcase.yaml
+++ b/tests/lib/thrift/hello/testcase.yaml
@@ -1,5 +1,7 @@
 common:
   tags: thrift cpp
+  # FIXME: zephyrproject-rtos/zephyr#45100
+  arch_exclude: posix
 tests:
   thrift.hello.newlib:
     filter: TOOLCHAIN_HAS_NEWLIB == 1
@@ -7,9 +9,9 @@ tests:
     platform_exclude: qemu_x86 qemu_leon3 qemu_malta qemu_malta_be
     arch_exclude: arc xtensa
     tags: newlib
-  thrift.hello.native:
-    arch_allow: posix
-    tags: native
+#  thrift.hello.native:
+#    arch_allow: posix
+#    tags: native
   thrift.hello.arcmwdtlib:
     toolchain_allow: arcmwdt
     platform_allow: nsim_hs nsim_em


### PR DESCRIPTION
Currently, the build depends on https://github.com/zephyrproject-rtos/zephyr/pull/43987

That did originally include a change to allow `CONFIG_POSIX_ARCH` and `CONFIG_POSIX_API` to co-exist but the arch/posix maintainer rejected the changes.

A workaround is required until zephyrproject-rtos/zephyr#45100 is resolved.

Fixes #81