### PR TITLE
samples + tests: re-enable additional integration targets

### DIFF
--- a/samples/lib/thrift/hello_client/sample.yaml
+++ b/samples/lib/thrift/hello_client/sample.yaml
@@ -10,6 +10,10 @@ common:
   arch_exclude: arc xtensa
   integration_platforms:
     - mps2_an385
+    - qemu_cortex_a53
+    - qemu_riscv32
+    - qemu_riscv64_smp
+    - qemu_x86
     - qemu_x86_64
 tests:
   thrift.ThriftTest.newlib.binaryProtocol:

--- a/samples/lib/thrift/hello_server/sample.yaml
+++ b/samples/lib/thrift/hello_server/sample.yaml
@@ -10,6 +10,10 @@ common:
   arch_exclude: arc xtensa
   integration_platforms:
     - mps2_an385
+    - qemu_cortex_a53
+    - qemu_riscv32
+    - qemu_riscv64_smp
+    - qemu_x86
     - qemu_x86_64
 tests:
   thrift.ThriftTest.newlib.binaryProtocol:

--- a/tests/lib/thrift/ThriftTest/testcase.yaml
+++ b/tests/lib/thrift/ThriftTest/testcase.yaml
@@ -8,6 +8,10 @@ common:
   integration_platforms:
     - mps2_an385
     - qemu_cortex_a53
+    - qemu_riscv32
+    - qemu_riscv64_smp
+    - qemu_x86
+    - qemu_x86_64
 tests:
   thrift.ThriftTest.newlib.binaryProtocol:
     tags: newlib

--- a/tests/lib/thrift/hello/testcase.yaml
+++ b/tests/lib/thrift/hello/testcase.yaml
@@ -8,6 +8,10 @@ common:
   integration_platforms:
     - mps2_an385
     - qemu_cortex_a53
+    - qemu_riscv32
+    - qemu_riscv64_smp
+    - qemu_x86
+    - qemu_x86_64
 tests:
   thrift.hello.newlib:
     tags: newlib

--- a/tests/lib/thrift/muzic/testcase.yaml
+++ b/tests/lib/thrift/muzic/testcase.yaml
@@ -8,6 +8,10 @@ common:
   integration_platforms:
     - mps2_an385
     - qemu_cortex_a53
+    - qemu_riscv32
+    - qemu_riscv64_smp
+    - qemu_x86
+    - qemu_x86_64
 tests:
   muzic.newlib:
     tags: newlib


### PR DESCRIPTION
Previously, there was an issue in the Zephyr SDK that prevented some targets from building properly. However, we do want to ensure that we have coverage for at least arm, aarch64, riscv, riscv64, x86, and x86_64, so re-enable those targets here.
